### PR TITLE
Upgrade to thrift 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,5 +32,5 @@ keywords = ["parquet", "hadoop"]
 
 [dependencies]
 ordered-float = "1.0"
-thrift = "0.12"
+thrift = "0.13"
 try_from = "0.3"


### PR DESCRIPTION
This is required to unblock the next release of Apache Arrow. See https://issues.apache.org/jira/browse/ARROW-7507