### PR TITLE
Update Parquet format to 2.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "parquet-format"
-version = "3.0.0"
+version = "4.0.0"
 license = "Apache-2.0"
 description = "Apache Parquet Format - thrift definition and generated Rust file"
 authors = [

--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@ The below summarises the version mappings.
 
 | parquet-format | parquet-format-rs |
 | -------------- | ----------------- |
-| 2.4.0          | 2.4.*             |
-| 2.5.0          | 2.5.*             |
-| 2.6.0          | 2.6.*             |
+| 2.8.0          | 4.0.*             |
 | 2.7.0          | 3.0.*             |
+| 2.6.0          | 2.6.*             |
+| 2.5.0          | 2.5.*             |
+| 2.4.0          | 2.4.*             |
 
 
 ## Updating Parquet format

--- a/parquet.thrift
+++ b/parquet.thrift
@@ -292,7 +292,7 @@ struct TimeType {
  * Allowed for physical types: INT32, INT64
  */
 struct IntType {
-  1: required byte bitWidth
+  1: required i8 bitWidth
   2: required bool isSigned
 }
 
@@ -457,6 +457,15 @@ enum Encoding {
   /** Dictionary encoding: the ids are encoded using the RLE encoding
    */
   RLE_DICTIONARY = 8;
+
+  /** Encoding for floating-point data.
+      K byte-streams are created where K is the size in bytes of the data type.
+      The individual bytes of an FP value are scattered to the corresponding stream and
+      the streams are concatenated.
+      This itself does not reduce the size of the data but can lead to better compression
+      afterwards.
+   */
+  BYTE_STREAM_SPLIT = 9;
 }
 
 /**
@@ -557,7 +566,7 @@ struct DataPageHeaderV2 {
   If missing it is considered compressed */
   7: optional bool is_compressed = 1;
 
-  /** optional statistics for this column chunk */
+  /** optional statistics for the data in this page **/
   8: optional Statistics statistics;
 }
 
@@ -637,6 +646,8 @@ struct PageHeader {
    *     uncompressed definition levels and the compressed column values.
    *     If no compression scheme is specified, the CRC shall be calculated on
    *     the uncompressed concatenation.
+   * - In encrypted columns, CRC is calculated after page encryption; the
+   *   encryption itself is performed after page compression (if compressed)
    * If enabled, this allows for disabling checksumming in HDFS if only a few
    * pages need to be read.
    **/

--- a/src/parquet_format.rs
+++ b/src/parquet_format.rs
@@ -298,6 +298,13 @@ pub enum Encoding {
   DeltaByteArray = 7,
   /// Dictionary encoding: the ids are encoded using the RLE encoding
   RleDictionary = 8,
+  /// Encoding for floating-point data.
+  /// K byte-streams are created where K is the size in bytes of the data type.
+  /// The individual bytes of an FP value are scattered to the corresponding stream and
+  /// the streams are concatenated.
+  /// This itself does not reduce the size of the data but can lead to better compression
+  /// afterwards.
+  ByteStreamSplit = 9,
 }
 
 impl Encoding {
@@ -320,6 +327,7 @@ impl TryFrom<i32> for Encoding {
       6 => Ok(Encoding::DeltaLengthByteArray),
       7 => Ok(Encoding::DeltaByteArray),
       8 => Ok(Encoding::RleDictionary),
+      9 => Ok(Encoding::ByteStreamSplit),
       _ => {
         Err(
           thrift::Error::Protocol(
@@ -2279,7 +2287,7 @@ pub struct DataPageHeaderV2 {
   /// is compressed with the compression_codec.
   /// If missing it is considered compressed
   pub is_compressed: Option<bool>,
-  /// optional statistics for this column chunk
+  /// optional statistics for the data in this page *
   pub statistics: Option<Statistics>,
 }
 
@@ -2901,6 +2909,8 @@ pub struct PageHeader {
   ///     uncompressed definition levels and the compressed column values.
   ///     If no compression scheme is specified, the CRC shall be calculated on
   ///     the uncompressed concatenation.
+  /// - In encrypted columns, CRC is calculated after page encryption; the
+  ///   encryption itself is performed after page compression (if compressed)
   /// If enabled, this allows for disabling checksumming in HDFS if only a few
   /// pages need to be read.
   /// 


### PR DESCRIPTION
Update Parquet format to 2.8.0 (the latest version). Also bump Cargo version to 2.8.0.