### PR TITLE
Document new version policy, bump to 3.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,13 @@
 
 [package]
 name = "parquet-format"
-version = "2.7.0"
+version = "3.0.0"
 license = "Apache-2.0"
 description = "Apache Parquet Format - thrift definition and generated Rust file"
 authors = [
     "Chao Sun <sunchao@apache.org>",
-    "Ivan Sadikov <ivan.sadikov@gmail.com>"
+    "Ivan Sadikov <ivan.sadikov@gmail.com>",
+    "Neville Dipale <nevilledips@gmail.com>"
 ]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,24 @@
 
 Apache Parquet format for Rust, hosting the Thrift definition file and the generated .rs file.
 
+## Usage and Versioning Policy
+
+This crate previously tracked the Parquet format versions, which made keeping semver guarantees sometimes challenging.
+As of version `3.0.0` of the crate, independent major versions are used whenever we update the Parquet format.
+
+The below summarises the version mappings.
+
+| parquet-format | parquet-format-rs |
+| -------------- | ----------------- |
+| 2.4.0          | 2.4.*             |
+| 2.5.0          | 2.5.*             |
+| 2.6.0          | 2.6.*             |
+| 2.7.0          | 3.0.*             |
+
+
 ## Updating Parquet format
 - Update the `parquet.thrift` file
 - Run `./generate_parquet_format.sh`
 - Commit changes
 
-Note that the version in `Cargo.toml` should match the Parquet format
-version of the `parquet.thrift` in [apache/parquet-format](https://github.com/apache/parquet-format).
+Note that the major version should be incremented when updating to a new Parquet format version.


### PR DESCRIPTION
This documents the new version policy, and bumps the version to 3.0.0 so we can make a new release.

I'll follow up with 4.0.0 after we release the next version.